### PR TITLE
Force camel case formatting of json responses

### DIFF
--- a/src/Stott.Optimizely.RobotsHandler/Presentation/RobotsController.cs
+++ b/src/Stott.Optimizely.RobotsHandler/Presentation/RobotsController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Text.Json;
 
 using EPiServer.Logging;
 
@@ -74,8 +75,12 @@ namespace Stott.Optimizely.RobotsHandler.Presentation
             }
 
             var model = _editViewModelBuilder.WithSiteId(siteIdGuid).Build();
+            var serializationOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
 
-            return Json(model);
+            return Json(model, serializationOptions);
         }
 
         [HttpPost]


### PR DESCRIPTION
Forcing camelCase properties names in json responses.  See #16 