### PR TITLE
Correct authorization error that prevented access to robots.txt

### DIFF
--- a/Sample/OptimizelyTwelveTest/Program.cs
+++ b/Sample/OptimizelyTwelveTest/Program.cs
@@ -1,46 +1,23 @@
-﻿namespace OptimizelyTwelveTest
+﻿namespace OptimizelyTwelveTest;
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+public class Program
 {
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.Hosting;
-
-    using System;
-
-    public class Program
+    public static void Main(string[] args)
     {
-        public static void Main(string[] args)
-        {
-            var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-            var isDevelopment = environment == Environments.Development;
+        CreateHostBuilder(args).Build().Run();
+    }
 
-            if (isDevelopment)
+    public static IHostBuilder CreateHostBuilder(string[] args)
+    {
+        return Host.CreateDefaultBuilder(args)
+            .ConfigureCmsDefaults()
+            .ConfigureWebHostDefaults(webBuilder =>
             {
-                //Development configuration
-            }
-
-            CreateHostBuilder(args, isDevelopment).Build().Run();
-        }
-
-        public static IHostBuilder CreateHostBuilder(string[] args, bool isDevelopment)
-        {
-            if (isDevelopment)
-            {
-                //Development configuration can be addded here, like local logging.
-                return Host.CreateDefaultBuilder(args)
-                    .ConfigureCmsDefaults()
-                    .ConfigureWebHostDefaults(webBuilder =>
-                    {
-                        webBuilder.UseStartup<Startup>();
-                    });
-            }
-            else
-            {
-                return Host.CreateDefaultBuilder(args)
-                    .ConfigureCmsDefaults()
-                    .ConfigureWebHostDefaults(webBuilder =>
-                    {
-                        webBuilder.UseStartup<Startup>();
-                    });
-            }
-        }
+                webBuilder.UseStartup<Startup>();
+                webBuilder.UseStaticWebAssets();
+            });
     }
 }

--- a/Sample/OptimizelyTwelveTest/Startup.cs
+++ b/Sample/OptimizelyTwelveTest/Startup.cs
@@ -55,14 +55,14 @@
                     .AddSwaggerGen()
                     .AddCspManager();
 
-            services.AddRobotsHandler();
-            //// services.AddRobotsHandler(authorizationOptions =>
-            //// {
-            ////     authorizationOptions.AddPolicy(RobotsConstants.AuthorizationPolicy, policy =>
-            ////     {
-            ////         policy.RequireRole("RobotAdmins");
-            ////     });
-            //// });
+            //// services.AddRobotsHandler();
+            services.AddRobotsHandler(authorizationOptions =>
+            {
+                authorizationOptions.AddPolicy(RobotsConstants.AuthorizationPolicy, policy =>
+                {
+                    policy.RequireRole("RobotAdmins");
+                });
+            });
 
             services.ConfigureApplicationCookie(options =>
             {

--- a/Sample/OptimizelyTwelveTest/appsettings.json
+++ b/Sample/OptimizelyTwelveTest/appsettings.json
@@ -28,6 +28,21 @@
                 "AutoResolveTypes": "true",
                 "AutoRemapStores": "true",
                 "DeleteAllOperationTimeout": "600"
+            },
+            "MappedRoles": {
+                "Items": {
+                    "CmsEditors": {
+                        "MappedRoles": [
+                            "WebEditors",
+                            "WebAdmins"
+                        ]
+                    },
+                    "CmsAdmins": {
+                        "MappedRoles": [
+                            "WebAdmins"
+                        ]
+                    }
+                }
             }
         }
     }

--- a/src/Stott.Optimizely.RobotsHandler/Presentation/RobotsAdminMenuProvider.cs
+++ b/src/Stott.Optimizely.RobotsHandler/Presentation/RobotsAdminMenuProvider.cs
@@ -12,7 +12,7 @@ namespace Stott.Optimizely.RobotsHandler.Presentation
     {
         public IEnumerable<MenuItem> GetMenuItems()
         {
-            var listMenuItem = new UrlMenuItem("Robots", "/global/cms/admin/stott.optimizely.robots", "/Robots/List")
+            var listMenuItem = new UrlMenuItem("Robots", "/global/cms/stott.optimizely.robots", "/Robots/List")
             {
                 IsAvailable = context => true,
                 SortIndex = SortIndex.Last + 1,

--- a/src/Stott.Optimizely.RobotsHandler/Presentation/RobotsAdminMenuProvider.cs
+++ b/src/Stott.Optimizely.RobotsHandler/Presentation/RobotsAdminMenuProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 
-using EPiServer.Authorization;
 using EPiServer.Shell.Navigation;
 
 using Stott.Optimizely.RobotsHandler.Common;

--- a/src/Stott.Optimizely.RobotsHandler/Presentation/RobotsController.cs
+++ b/src/Stott.Optimizely.RobotsHandler/Presentation/RobotsController.cs
@@ -37,6 +37,7 @@ public class RobotsController : Controller
 
     [HttpGet]
     [Route("robots.txt")]
+    [AllowAnonymous]
     public IActionResult Index()
     {
         try
@@ -58,7 +59,6 @@ public class RobotsController : Controller
     }
 
     [HttpGet]
-    [Authorize(Roles = "CmsAdmin,WebAdmins,Administrators")]
     [Route("[controller]/[action]")]
     public IActionResult List()
     {
@@ -68,7 +68,6 @@ public class RobotsController : Controller
     }
 
     [HttpGet]
-    [Authorize(Roles = "CmsAdmin,WebAdmins,Administrators")]
     [Route("[controller]/[action]")]
     public IActionResult Details(string siteId)
     {
@@ -83,7 +82,6 @@ public class RobotsController : Controller
     }
 
     [HttpPost]
-    [Authorize(Roles = "CmsAdmin,WebAdmins,Administrators")]
     [Route("[controller]/[action]")]
     public IActionResult Save(RobotsEditViewModel formSubmitModel)
     {


### PR DESCRIPTION
- Removes old authorization attributes against controller actions that were for fixed roles.
  - This was previously deprecated by a controller level action allowing for customisation of access.
- Adds AllowAnonymous to the controller action that returns the robots.txt result.
  - closes #35 
- Moves the robots menu to the top level so that SEO users can be given robots.txt access without needing admin access