### PR TITLE
Add UTF-8 charset to text response content types

### DIFF
--- a/src/Stott.Optimizely.RobotsHandler.Test/Llms/LlmsTextControllerTests.cs
+++ b/src/Stott.Optimizely.RobotsHandler.Test/Llms/LlmsTextControllerTests.cs
@@ -71,7 +71,7 @@ public class LlmsTextControllerTests
         var contentResult = result as ContentResult;
         Assert.That(contentResult, Is.Not.Null);
         Assert.That(contentResult.Content, Is.EqualTo(robotsContent));
-        Assert.That(contentResult.ContentType, Is.EqualTo("text/plain"));
+        Assert.That(contentResult.ContentType, Is.EqualTo("text/plain; charset=utf-8"));
         Assert.That(contentResult.StatusCode, Is.EqualTo(200));
     }
 }

--- a/src/Stott.Optimizely.RobotsHandler.Test/Robots/RobotsTextControllerTests.cs
+++ b/src/Stott.Optimizely.RobotsHandler.Test/Robots/RobotsTextControllerTests.cs
@@ -71,7 +71,7 @@ public sealed class RobotsTextControllerTests
         var contentResult = result as ContentResult;
         Assert.That(contentResult, Is.Not.Null);
         Assert.That(contentResult.Content, Is.EqualTo(robotsContent));
-        Assert.That(contentResult.ContentType, Is.EqualTo("text/plain"));
+        Assert.That(contentResult.ContentType, Is.EqualTo("text/plain; charset=utf-8"));
         Assert.That(contentResult.StatusCode, Is.EqualTo(200));
     }
 }

--- a/src/Stott.Optimizely.RobotsHandler/Llms/LlmsTextController.cs
+++ b/src/Stott.Optimizely.RobotsHandler/Llms/LlmsTextController.cs
@@ -37,7 +37,7 @@ public sealed class LlmsTextController(
             return new ContentResult
             {
                 Content = llmsContent,
-                ContentType = "text/plain",
+                ContentType = "text/plain; charset=utf-8",
                 StatusCode = 200
             };
         }

--- a/src/Stott.Optimizely.RobotsHandler/Robots/RobotsTextController.cs
+++ b/src/Stott.Optimizely.RobotsHandler/Robots/RobotsTextController.cs
@@ -31,7 +31,7 @@ public sealed class RobotsTextController(
             return new ContentResult
             {
                 Content = robotsContent,
-                ContentType = "text/plain",
+                ContentType = "text/plain; charset=utf-8",
                 StatusCode = 200
             };
         }


### PR DESCRIPTION
This PR updates the Content-Type headers for llms.txt and robots.txt responses from `text/plain` to `text/plain; charset=utf-8`.

This makes the response encoding explicit for clients consuming these text files.

I have targeted `develop` because the repository appears to use it as the integration branch.

The change should also be relevant for the older CMS 12 / .NET 8 line. I am happy to create a separate backport PR if there is a maintained branch for that version.